### PR TITLE
migrate from v1 to v2 for dhcp resource

### DIFF
--- a/lib/chef/provider/aws_vpc.rb
+++ b/lib/chef/provider/aws_vpc.rb
@@ -327,7 +327,10 @@ class Chef::Provider::AwsVpc < Chef::Provisioning::AWSDriver::AWSProvider
     desired_dhcp_options = Chef::Resource::AwsDhcpOptions.get_aws_object(new_resource.dhcp_options, resource: new_resource)
     if dhcp_options != desired_dhcp_options
       converge_by "change DHCP options for #{new_resource.to_s} to #{new_resource.dhcp_options} (#{desired_dhcp_options.id}) - was #{dhcp_options.id}" do
-        vpc.dhcp_options = desired_dhcp_options
+        vpc.associate_dhcp_options({
+          dhcp_options_id: desired_dhcp_options.id, # required
+          dry_run: false,
+        })
       end
     end
   end

--- a/lib/chef/provisioning/aws_driver/aws_tagger.rb
+++ b/lib/chef/provisioning/aws_driver/aws_tagger.rb
@@ -37,7 +37,7 @@ class AWSTagger
     Retryable.retryable(
       :tries => 20,
       :sleep => lambda { |n| [2**n, 10].min },
-      :on => [Base64, ::Aws::Errors::ServiceError,]
+      :on => [::Aws::EC2::Errors, Aws::S3::Errors, ::Aws::S3::Errors::ServiceError,]
     ) do |retries, exception|
       if retries > 0
         Chef::Log.info "Retrying the tagging, previous try failed with #{exception.inspect}"

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -779,8 +779,7 @@ EOD
     end
 
     def ec2
-      aws_config.delete(:proxy_uri)
-      @ec2 ||= ::Aws::EC2::Client.new( aws_config)
+      @ec2 ||= ::Aws::EC2::Client.new(aws_config)
     end
 
     AWS_V2_SERVICES.each do |load_name, short_name|
@@ -814,7 +813,6 @@ EOD
     end
 
     def s3_client
-      aws_config.delete(:proxy_uri)
       @s3 ||= ::Aws::S3::Client.new( aws_config)
     end
 

--- a/lib/chef/resource/aws_dhcp_options.rb
+++ b/lib/chef/resource/aws_dhcp_options.rb
@@ -53,7 +53,14 @@ class Chef::Resource::AwsDhcpOptions < Chef::Provisioning::AWSDriver::AWSResourc
 
   def aws_object
     driver, id = get_driver_and_id
-    result = driver.ec2_resource.dhcp_options(id) if id
-    result && result.exists? ? result : nil
+    ec2_resource = ::Aws::EC2::Resource.new(driver.ec2)
+    result = ec2_resource.dhcp_options(id) if id
+    result && exists?(result) ? result : nil
+  end
+
+  def exists?(result)
+    return true if result.data
+  rescue ::Aws::EC2::Errors::InvalidDhcpOptionIDNotFound
+    return false
   end
 end


### PR DESCRIPTION
Update the code of `aws_dhcp_options` resource to use AWS SDK V2